### PR TITLE
Fixing thread safety issue relating to cached setter lookups

### DIFF
--- a/ioc.cfc
+++ b/ioc.cfc
@@ -547,8 +547,7 @@ component {
                     if ( !structKeyExists( variables.settersInfo, beanName ) ) {
                         variables.settersInfo[ beanName ] = findSetters( bean, info.metadata );
                     }
-				    var setterMeta = variables.settersInfo[ beanName ];
-				    setterMeta.bean = bean;
+				    var setterMeta = {setters=variables.settersInfo[ beanName ].setters, bean=bean};
 				    accumulator.injection[ beanName ] = setterMeta; 
 				    for ( var property in setterMeta.setters ) {
 					    resolveBeanCreate( property, accumulator );


### PR DESCRIPTION
We ran into an issue where transient beans where being returned with their setters not set.  It only happened when there were concurrent threads accessing instances of the same bean class.  

Thanks for the project!
Matt
