### PR TITLE
Null Value Fix for injectProperties

### DIFF
--- a/ioc.cfc
+++ b/ioc.cfc
@@ -133,16 +133,18 @@ component {
 
 
 	// given a bean (by name, by type or by value), call the named
-    // setters with the specified property values
+	// setters with the specified property values
 	public any function injectProperties( any bean, struct properties ) {
 		if ( isSimpleValue( bean ) ) {
-            if ( containsBean( bean ) ) bean = getBean( bean );
-            else bean = createObject( 'component', bean );
-        }
+			if ( containsBean( bean ) ) bean = getBean( bean );
+			else bean = createObject( 'component', bean );
+		}
 		for ( var property in properties ) {
-			var args = { };
-			args[ property ] = properties[ property ];
-			evaluate( 'bean.set#property#( argumentCollection = args )' );
+			if ( !isNull( properties[property ] ) ) {
+				var args = { };
+				args[ property ] = properties[ property ];
+				evaluate( 'bean.set#property#( argumentCollection = args )' );
+			}
 		}
 		return bean;
 	}

--- a/tests/InjectProperties.cfc
+++ b/tests/InjectProperties.cfc
@@ -2,6 +2,7 @@ component extends="mxunit.framework.TestCase" {
 
     function setup() {
         variables.ioc = new ioc( "" );
+        variables.ioc2 = new ioc( "/tests/model" );
     }
 
     function shouldInjectWithType() {
@@ -30,6 +31,13 @@ component extends="mxunit.framework.TestCase" {
         var bean = variables.ioc.injectProperties( "configObject", { name = "ByName" } );
         assertEquals( "ByName", bean.getName() );
         assertEquals( "data", bean.getConfig() );
+    }
+
+    function shouldInjectWithNullValues( numeric userid, string username ) {
+        // use arguments to pass into bean, argument values are null
+        var bean = variables.ioc2.injectProperties( "user2Bean", arguments );
+        assertEquals( "0", bean.getUserid() );
+        assertEquals( "defaultuser", bean.getUsername() );
     }
 
 }

--- a/tests/model/beans/user2Bean.cfc
+++ b/tests/model/beans/user2Bean.cfc
@@ -1,0 +1,10 @@
+component output="false" accessors="true" {
+
+	property username;
+	property userid;
+	public any function init( numeric userid = 0, string username = "defaultuser" ) {
+		setusername( arguments.username );
+		setuserid( arguments.userid );
+		return this;
+	}
+}


### PR DESCRIPTION
This patch corrects the issue where a struct is passed into the injectProperties feature that has NULL assigned for a value.  We simply check for a NULL before calling the evaluate function.

Tested on Railo 4.0+ and CF 9.0.1.  Test case included.
