### PR TITLE
Auto-ignore FW/1 and DI/1

### DIFF
--- a/ioc.cfc
+++ b/ioc.cfc
@@ -23,7 +23,8 @@ component {
 		variables.beanInfo = { };
 		variables.beanCache = { };
         variables.settersInfo = { };
-		variables.autoExclude = [ '/WEB-INF', '/Application.cfc' ];
+		variables.autoExclude = [ '/WEB-INF', '/Application.cfc',
+                                  'framework.cfc', 'ioc.cfc' ];
         variables.listeners = 0;
 		setupFrameworkDefaults();
 		return this;
@@ -607,7 +608,7 @@ component {
             throw 'singletonPattern and transientPattern are mutually exclusive';
         }
 				
-		variables.config.version = '0.4.9';
+		variables.config.version = '0.4.10';
 	}
 	
 	


### PR DESCRIPTION
Caveat: you can't manage beans call ioc.cfc or framework.cfc any more. Technically that's a breaking change but if it actually breaks anything, I'd be very surprised. If it does, I'll provide a way to override this new behavior.

The justification is that DI/1 must not "accidentally" try to manage FW/1 (and should even try to manage itself) because it will try to inject itself into FW/1 and that will fail, because the FW/1 bean that DI/1 created will not be properly initialized... so this will lead to all sorts of confusing and very hard to debug problems!
